### PR TITLE
Config parser, row writing for Python3

### DIFF
--- a/fileintel.py
+++ b/fileintel.py
@@ -7,7 +7,7 @@
 # Required for complex command line argument parsing.
 import argparse
 # Required for configuration files
-import ConfigParser
+from configparser import ConfigParser
 # Required for CSV
 import csv
 # Required for STDOUT
@@ -93,7 +93,7 @@ parser.add_argument('-r',
 args = parser.parse_args()
 
 # Parse Configuration File
-ConfigFile = ConfigParser.ConfigParser()
+ConfigFile = ConfigParser()
 ConfigFile.read(args.ConfigurationFile)
 
 # Setup the headers list
@@ -226,7 +226,10 @@ for filehash in filehashes:
             output.writerow(Headers)
 
         # Print out the data
-        output.writerow([unicode(field).encode('utf-8') for field in row])
+        try:
+            output.writerow([unicode(field).encode('utf-8') for field in row])
+        except:
+            output.writerow([str(field) for field in row])
 
         # This turns off headers for remaining rows
         PrintHeaders = False


### PR DESCRIPTION
Hello and happy almost Hacktoberfest! 

This PR represents a few small changes to make `fileintel` Python3-compatible. These changes are identical to the [ones I introduced in hostintel](https://github.com/keithjjones/hostintel/pull/16) back in March. 

Please let me know if you have any questions or would like to see any changes. 

This has been tested with Python 3.8.

Thanks!

--
Brie